### PR TITLE
💄 Add base figma colors

### DIFF
--- a/code.tsx
+++ b/code.tsx
@@ -57,8 +57,41 @@ function getKeyDecorator(column: Column): KeyDecorator {
   }[column.keyType]
 }
 
+const colors = [
+  { option: "#1e1e1e", tooltip: "Black" },
+  { option: "#b3b3b3", tooltip: "Gray" },
+  { option: "#f24822", tooltip: "Red" },
+  { option: "#ffa629", tooltip: "Orange" },
+  { option: "#ffcd29", tooltip: "Yellow" },
+  { option: "#14ae5c", tooltip: "Green" },
+  { option: "#0d99ff", tooltip: "Blue" },
+  { option: "#9747ff", tooltip: "Violet" },
+  { option: "#ffffff", tooltip: "White" },
+]
+
+function hexToRgb (hex: string) {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
+  if (!result) {
+    throw new Error(`Invalid hex color ${hex}`)
+  }
+
+  return {
+    r: parseInt(result[1], 16),
+    g: parseInt(result[2], 16),
+    b: parseInt(result[3], 16),
+  }
+}
+
+function chooseTextColor (backgroundColor: string): WidgetJSX.Color {
+  const { r, g, b } = hexToRgb(backgroundColor)
+
+  return (r * 0.299 + g * 0.587 + b * 0.114 > 186 )
+    ? { r: 0, g: 0, b: 0, a: 1 }
+    : { r: 1, g: 1, b: 1, a: 1 }
+}
+
 function DatabaseTableWidget() {
-  const [theme, setTheme] = useSyncedState("theme", "#000c86")
+  const [theme, setTheme] = useSyncedState("theme", colors[0].option)
   const [tableName, setTableName] = useSyncedState("tableName", null)
   const [columns, setColumns] = useSyncedState("columns", (): Column[] => [])
 
@@ -76,16 +109,7 @@ function DatabaseTableWidget() {
         propertyName: "colors",
         tooltip: "Color selector",
         selectedOption: theme,
-        options: [
-          {
-            option: "#000c86",
-            tooltip: "Blue",
-          },
-          {
-            option: "#000000",
-            tooltip: "Black",
-          }
-        ],
+        options: colors,
       },
       {
         itemType: "action",
@@ -133,7 +157,7 @@ function DatabaseTableWidget() {
           width="fill-parent"
           inputBehavior="truncate"
           fontWeight={700}
-          fill="#ffffff"
+          fill={chooseTextColor(theme)}
           horizontalAlignText="center"
           verticalAlignText="center"
           value={tableName}


### PR DESCRIPTION
Got base colors from ellipse upper row options and added to the widget.
I choose not to add the bottom ones because the options would not be aligned like it is in the ellipse.

Also used a function from [this](https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color) StackOverflow question do dynamically choose White/Black color for Table name based on the background color, to have always a better contrast

![image](https://user-images.githubusercontent.com/5989971/168114150-2ea96c51-1de2-4e9b-b1fc-e138db632ccc.png)
![image](https://user-images.githubusercontent.com/5989971/168116245-38e202f5-57de-4f07-ac1d-5ef6a7c59b06.png)
![image](https://user-images.githubusercontent.com/5989971/168116299-5428c988-d3bb-4f1f-8ad1-177c24f0ef84.png)
